### PR TITLE
Add Node::GetType

### DIFF
--- a/alt-config.h
+++ b/alt-config.h
@@ -198,6 +198,8 @@ namespace alt::config
 			return *this;
 		}
 
+		Type GetType() { return type; }
+
 		bool IsNone() const { return type == Type::NONE; }
 		bool IsScalar() const { return type == Type::SCALAR; }
 		bool IsList() const { return type == Type::LIST; }


### PR DESCRIPTION
Adds `Node::GetType()` so you can use a switch statement to check for the type of the Node, instead of using the `Is*` methods in an else-if chain