### PR TITLE
Change Emitter::Emit to static method

### DIFF
--- a/alt-config.h
+++ b/alt-config.h
@@ -591,7 +591,7 @@ namespace alt::config
 	class Emitter
 	{
 	public:
-		void Emit(Node& node, std::ostream& os, int indent = 0, bool isLast = true)
+		static void Emit(Node& node, std::ostream& os, int indent = 0, bool isLast = true)
 		{
 			std::string _indent(indent * 2, ' ');
 


### PR DESCRIPTION
There is no reason to need an instance of `Emitter` to call that method, as that class has no other methods/properties.
This also doesn't break existing code, as you can still create an instance and call that method.