### PR TITLE
Fix compiler warning

### DIFF
--- a/alt-config.h
+++ b/alt-config.h
@@ -284,7 +284,7 @@ namespace alt::config
 				{
 					return std::stod(val);
 				}
-				catch (const std::invalid_argument& e)
+				catch (const std::invalid_argument&)
 				{
 					throw Error{ "Not a number" };
 				}


### PR DESCRIPTION
On line 287 in catch there is an unused variable "e", this makes compilers complain, so I removed it.